### PR TITLE
add python script to retrieve apikey over BLE

### DIFF
--- a/utils/retrieve_api_key.py
+++ b/utils/retrieve_api_key.py
@@ -1,0 +1,44 @@
+from encodings import utf_8
+import sys
+import asyncio
+import logging
+
+from bleak import BleakClient, BleakScanner, BleakError
+
+logger = logging.getLogger(__name__)
+
+ADDRESS = (
+    "30:1B:97:00:00:00"
+)
+MY_PAIRING_CODE = 123123
+
+pairingCodeChar = '59DA0011-12F4-25A6-7D4F-55961DCE4205'
+powerpalUUIDChar ='59DA0009-12F4-25A6-7D4F-55961DCE4205'
+
+def convert_pairing_code(original_pairing_code):
+    return original_pairing_code.to_bytes(4, byteorder='little')
+
+
+async def main(address, my_pairing_code):
+    async with BleakClient(address) as client:
+        logger.info(f"Connected: {client.is_connected}")
+
+
+        logger.info(f"Authenticating with pairing_code: {my_pairing_code}, converted: {convert_pairing_code(my_pairing_code)}")
+        await client.write_gatt_char(pairingCodeChar, convert_pairing_code(my_pairing_code), response=False)
+        logger.info('Writing: Success')
+
+        await asyncio.sleep(0.5)
+
+        logger.info(f"Attempting to retrieve apikey (Powerpal UUID)...")
+
+        apikey = await client.read_gatt_char(powerpalUUIDChar)
+
+        logger.info(f"Retrieved apikey: {apikey}")
+
+        # while True:
+        #     await asyncio.sleep(0.1)
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    asyncio.run(main((sys.argv[1] if len(sys.argv) >= 2 else ADDRESS),(sys.argv[2] if len(sys.argv) == 3 else MY_PAIRING_CODE)))


### PR DESCRIPTION
After reverse engineering the Powerpal BLE comms I didn't think to bother with any of the REST API because that had been covered pretty well by a couple of other github projects.

But on coming back to it I realised that there was one step that is still a bit of a pain and mystery, retrieving the apikey! (though I believe now you can maybe apply for it, this is probably still more convenient)

The Apikey is actually stored locally on the Powerpal, behind the 'UUID' (`59DA0009-12F4-25A6-7D4F-55961DCE4205`) characteristic.

This is a super simple python script to retrieve it, and only requires the Powerpal MAC address (can easily be found by scanning for bluetooth devices), and the pairing code given to you with your Powerpal (can also be found within the Powerpal Application)

I don't currently have access to a  Powerpal to test this on, so would really appreciate if you could give it a go and let me know if it works (it's also possible the data that comes back might need to have it's bytes reversed)

Can run by adding your mac and pairing key as arguments, or by changing them in the script:
`python3 utils/retrieve_api_key.py "12:34:56:78:90:AB" 123123`