### PR TITLE
Move device_class and native_unit_of_measurement to the sensor class

### DIFF
--- a/custom_components/powerpal/sensor.py
+++ b/custom_components/powerpal/sensor.py
@@ -5,7 +5,7 @@ from homeassistant.components.sensor import (
     STATE_CLASS_MEASUREMENT,
 )
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
-from homeassistant.const import ENERGY_KILO_WATT_HOUR, DEVICE_CLASS_ENERGY
+from homeassistant.const import ENERGY_WATT_HOUR, POWER_WATT, DEVICE_CLASS_ENERGY, DEVICE_CLASS_POWER
 
 from .const import NAME, DOMAIN, ICON, CONF_DEVICE_ID, ATTRIBUTION
 
@@ -26,16 +26,6 @@ class PowerpalSensor(CoordinatorEntity):
     def __init__(self, coordinator, config_entry):
         super().__init__(coordinator)
         self.config_entry = config_entry
-
-    @property
-    def native_unit_of_measurement(self) -> str:
-        """Return the native unit of measurement."""
-        return ENERGY_KILO_WATT_HOUR
-
-    @property
-    def device_class(self) -> str:
-        """Return the device class."""
-        return DEVICE_CLASS_ENERGY
 
     @property
     def device_info(self):
@@ -73,14 +63,24 @@ class PowerpalTotalConsumptionSensor(PowerpalSensor, SensorEntity):
         return f"powerpal-total-{self.config_entry.entry_id}"
 
     @property
+    def device_class(self) -> str:
+        """Return the device class."""
+        return DEVICE_CLASS_ENERGY
+
+    @property
     def state_class(self) -> str:
         """Return the state class."""
         return STATE_CLASS_TOTAL_INCREASING
 
     @property
+    def native_unit_of_measurement(self) -> str:
+        """Return the native unit of measurement."""
+        return ENERGY_WATT_HOUR
+
+    @property
     def native_value(self):
         """Return the native value of the sensor."""
-        return self.coordinator.data.get("total_watt_hours") / 1000
+        return self.coordinator.data.get("total_watt_hours")
 
 
 class PowerpalLiveConsumptionSensor(PowerpalSensor, SensorEntity):
@@ -95,11 +95,21 @@ class PowerpalLiveConsumptionSensor(PowerpalSensor, SensorEntity):
         return f"powerpal-live-{self.config_entry.entry_id}"
 
     @property
+    def device_class(self) -> str:
+        """Return the device class."""
+        return DEVICE_CLASS_POWER
+
+    @property
     def state_class(self) -> str:
         """Return the state class."""
         return STATE_CLASS_MEASUREMENT
 
     @property
+    def native_unit_of_measurement(self) -> str:
+        """Return the native unit of measurement."""
+        return POWER_WATT
+
+    @property
     def native_value(self):
         """Return the native value of the sensor."""
-        return (self.coordinator.data.get("last_reading_watt_hours") * 60) / 1000
+        return (self.coordinator.data.get("last_reading_watt_hours") * 60)

--- a/custom_components/powerpal/sensor.py
+++ b/custom_components/powerpal/sensor.py
@@ -1,11 +1,15 @@
 """Sensor platform for powerpal."""
 from homeassistant.components.sensor import (
     SensorEntity,
+    SensorDeviceClass,
     STATE_CLASS_TOTAL_INCREASING,
     STATE_CLASS_MEASUREMENT,
 )
+from homeassistant.const import (
+    UnitOfPower,
+    UnitOfEnergy,
+)
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
-from homeassistant.const import ENERGY_WATT_HOUR, POWER_WATT, DEVICE_CLASS_ENERGY, DEVICE_CLASS_POWER
 
 from .const import NAME, DOMAIN, ICON, CONF_DEVICE_ID, ATTRIBUTION
 
@@ -65,7 +69,7 @@ class PowerpalTotalConsumptionSensor(PowerpalSensor, SensorEntity):
     @property
     def device_class(self) -> str:
         """Return the device class."""
-        return DEVICE_CLASS_ENERGY
+        return SensorDeviceClass.ENERGY
 
     @property
     def state_class(self) -> str:
@@ -75,12 +79,12 @@ class PowerpalTotalConsumptionSensor(PowerpalSensor, SensorEntity):
     @property
     def native_unit_of_measurement(self) -> str:
         """Return the native unit of measurement."""
-        return ENERGY_WATT_HOUR
+        return UnitOfEnergy.KILO_WATT_HOUR
 
     @property
     def native_value(self):
         """Return the native value of the sensor."""
-        return self.coordinator.data.get("total_watt_hours")
+        return self.coordinator.data.get("total_watt_hours") / 1000
 
 
 class PowerpalLiveConsumptionSensor(PowerpalSensor, SensorEntity):
@@ -97,7 +101,7 @@ class PowerpalLiveConsumptionSensor(PowerpalSensor, SensorEntity):
     @property
     def device_class(self) -> str:
         """Return the device class."""
-        return DEVICE_CLASS_POWER
+        return SensorDeviceClass.POWER
 
     @property
     def state_class(self) -> str:
@@ -107,9 +111,9 @@ class PowerpalLiveConsumptionSensor(PowerpalSensor, SensorEntity):
     @property
     def native_unit_of_measurement(self) -> str:
         """Return the native unit of measurement."""
-        return POWER_WATT
+        return UnitOfPower.KILO_WATT
 
     @property
     def native_value(self):
         """Return the native value of the sensor."""
-        return (self.coordinator.data.get("last_reading_watt_hours") * 60)
+        return (self.coordinator.data.get("last_reading_watt_hours") * 60) / 1000


### PR DESCRIPTION
Move device_class and native_unit_of_measurement from the device class to the sensor class.
Fixes issue with HomeAssistant complaining that the live consumption sensor has the wrong device_class.
Also adjusted the native_unit_of_measurement to reduce calculations within the sensors - HomeAssistant can handle display of the units gracefully.

Closes #16 